### PR TITLE
Fix eslint linebreaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = false
+
+[*.ts,*.js]
+indent_style = tab
+indent_size = 2
+
+[*.json]
+indent_style = space
+indent_size = 4

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
 		],
 		"linebreak-style": [
 			"error",
-			"windows",
+			"unix",
 		],
 		"quotes": [
 			"error",


### PR DESCRIPTION
While creating #21, VSCode and ESLint were adding the wrong linebreaks due to a misconfiguration. This PR also includes an [`.editorconfig` file](https://editorconfig.org/) which would ensure most editors are configured the same. It prevents VSCode from adding newlines at the end of files. (Note that Editorconfig is not installed by default in VSCode ([link](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)), although it is very popular.)

I think setting `trim_trailing_whitespace = true` can also help in the future.